### PR TITLE
use spdy (http/2) for https server

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^15.4.1",
     "react-helmet": "^4.0.0",
     "react-router": "4.0.0-alpha.6",
+    "spdy": "^3.4.4",
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-hot-middleware": "^2.14.0"

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -70,10 +70,10 @@ app.get('*', (req, res) => {
 // ---------------------------
 app.listen(HTTP_PORT, (err) => {
   if (err) {
-    return console.error(err);
+    return console.error(err); // eslint-disable-line no-console
   }
 
-  return console.log(`Listening at http://localhost:${HTTP_PORT}`);
+  return console.log(`Listening at http://localhost:${HTTP_PORT}`); // eslint-disable-line no-console
 });
 
 // Launch https server.
@@ -88,9 +88,9 @@ spdy
   .createServer(sslOptions, app)
   .listen(HTTPS_PORT, (err) => {
     if (err) {
-      console.error(err);
+      console.error(err); // eslint-disable-line no-console
       return process.exit(1);
     }
 
-    return console.log(`Listening at https://localhost:${HTTPS_PORT}`);
+    return console.log(`Listening at https://localhost:${HTTPS_PORT}`); // eslint-disable-line no-console
   });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const https = require('https');
+const spdy = require('spdy');
 
 const express = require('express');
 const bodyParser = require('body-parser');
@@ -84,11 +84,13 @@ const sslOptions = {
   passphrase: process.env.SSL_CERT_PASS,
 };
 
-const httpsServer = https.createServer(sslOptions, app);
-httpsServer.listen(HTTPS_PORT, (err) => {
-  if (err) {
-    return console.error(err);
-  }
+spdy
+  .createServer(sslOptions, app)
+  .listen(HTTPS_PORT, (err) => {
+    if (err) {
+      console.error(err);
+      return process.exit(1);
+    }
 
-  return console.log(`Listening at https://localhost:${HTTPS_PORT}`);
-});
+    return console.log(`Listening at https://localhost:${HTTPS_PORT}`);
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5306,7 +5306,7 @@ spdy-transport@^2.0.15:
     readable-stream "^2.0.1"
     wbuf "^1.4.0"
 
-spdy@^3.4.1:
+spdy@^3.4.1, spdy@^3.4.4:
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/spdy/-/spdy-3.4.4.tgz#e0406407ca90ff01b553eb013505442649f5a819"
   dependencies:


### PR DESCRIPTION
Should provide better performance (compressed headers, improved concurrency, etc), as well as open up the door for additional features (like server push!)